### PR TITLE
Run tests with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ buzzy.pc
 *.os
 *.so
 *.dylib
+
+!.travis.yml
+!.travis/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+compiler:
+  - clang
+  - gcc
+env:
+  - ARCH=i386
+  - ARCH=amd64
+os:
+  - linux
+  - osx
+install: .travis/install
+script: .travis/test
+
+# In addition to pull requests, always build these branches
+branches:
+  only:
+    - master
+    - develop

--- a/.travis/install
+++ b/.travis/install
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ "$TRAVIS_OS_NAME" = linux ]; then
+    sudo apt-get update -qq
+
+    if [ "$ARCH" = i386 ]; then
+        sudo apt-get install gcc-multilib
+    fi
+
+    sudo apt-get install check:$ARCH
+else
+    brew install --universal check
+fi

--- a/.travis/test
+++ b/.travis/test
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+mkdir .build
+cd .build
+
+if [ "$TRAVIS_OS_NAME" = linux ]; then
+    if [ "$ARCH" = i386 ]; then
+        ARCH_FLAGS="-m32"
+    else
+        ARCH_FLAGS=""
+    fi
+elif [ "$TRAVIS_OS_NAME" = osx ]; then
+    if [ "$ARCH" = i386 ]; then
+        ARCH_FLAGS="-arch i386"
+    else
+        ARCH_FLAGS="-arch x86_64"
+    fi
+fi
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_C_FLAGS_RELWITHDEBINFO="-g -O3 $ARCH_FLAGS"
+make
+make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Buzzy package manager
 
+[![Build Status](https://img.shields.io/travis/redjack/buzzy/develop.svg)](https://travis-ci.org/redjack/buzzy)
+
 Buzzy is a package manager that isn't tied to one particular operating system or
 distribution.  It's useful for third-party software developers that would like
 to provide native binary packages for the software that they write, without


### PR DESCRIPTION
Use [Travis CI](https://travis-ci.org) to build pull requests and branches.  Travis only provides 64-bit build VMs, so we use some multilib magic to test both 32- and 64-bit builds. This patch also has support for [building on OS X](http://docs.travis-ci.com/user/multi-os/) once Travis CI reenables it.